### PR TITLE
Add end2end testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "jest --runInBand",
     "test:integration": "jest integration.test.ts --runInBand",
     "test:unit": "jest spec.ts",
+    "test:e2e": "jest e2e --runInBand",
     "validate": "yarn graphql:validate"
   },
   "dependencies": {

--- a/test/nuxt.setup.e2e.test.ts
+++ b/test/nuxt.setup.e2e.test.ts
@@ -1,0 +1,33 @@
+// @ts-ignore: No typescript info available yet https://github.com/nuxt/nuxt.js/issues/7651
+import { Nuxt, loadNuxt } from 'nuxt'
+
+// TODO: This doesn't work, reflect metadata is still missing...
+import '../api/tsyringe.config'
+import 'reflect-metadata'
+
+// Init Nuxt.js and start listening on localhost:5000
+describe('Nuxt setup', () => {
+  // We keep a reference to Nuxt so we can close
+  // the server at the end of the test
+  let nuxt: Nuxt = null
+  beforeAll(async () => {
+    // For some reason building nuxt from code doesn't work
+    // so developers need to run `yarn build` before
+    /*
+    const nuxtForBuild = await loadNuxt({ for: 'build' })
+    await build(nuxtForBuild)
+    */
+    const isDev = process.env.NODE_ENV !== 'production'
+    nuxt = await loadNuxt({ for: isDev ? 'dev' : 'start' })
+  })
+
+  afterAll(() => {
+    nuxt.close()
+  })
+
+  it('renders the dashboard correctly', async () => {
+    const context = {}
+    const { html } = await nuxt.renderRoute('/', context)
+    expect(html).toMatchSnapshot()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -9697,12 +9697,7 @@ jest@^26.6.3:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
-jiti@^1.3.0:
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.6.4.tgz#63453b602d0234f8bd7ce638f03f0e74ef99be12"
-  integrity sha512-ICUtP0/rAyT/GaaDG0vj6fmWzx5yjFc7v+L1MAEARGl1+lrdJ8wtJNChr+ZGEdPoOhFwdhtcDO5VM2TNNgPpjQ==
-
-jiti@^1.9.2:
+jiti@^1.3.0, jiti@^1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.9.2.tgz#2ee44830883dbb1b2e222adc053c3052d0bf3b61"
   integrity sha512-wymUBR/YGGVNVRAxX52yvFoZdUAYKEGjk0sYrz6gXLCvMblnRvJAmDUnMvQiH4tUHDBtbKHnZ4GT3R+m3Hc39A==


### PR DESCRIPTION
Currently doesn't work:
```
      [error] ServerMiddleware Error: Reflect.metadata is not a function
        at api\documents\user.document.service.ts:15:76
        at f (node_modules\jiti\dist\jiti.js:1:54628)
        at api\documents\resolvers.ts:10:21
        at f (node_modules\jiti\dist\jiti.js:1:54628)
        at api\user\resolvers.ts:5:18
        at f (node_modules\jiti\dist\jiti.js:1:54628)
        at api\resolvers.ts:6:18
        at f (node_modules\jiti\dist\jiti.js:1:54628)
        at api\schema.ts:5:41
        at f (node_modules\jiti\dist\jiti.js:1:54628)
```
Already reported but needs reproduction: https://github.com/nuxt/nuxt.js/issues/8372
Related: https://github.com/nuxt-community/nuxt-property-decorator/issues/55

I tried now for 3 hours to fix / reproduce this with no success. Let's wait for Nuxt 3 then!