### PR TITLE
first attempt at docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.env
+.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3"
+services:
+  postgres:
+    image: postgres
+    container_name: postgres
+    restart: always
+    environment:
+    - POSTGRES_PASSWORD=yourPassword
+    - POSTGRES_HOST_AUTH_METHOD=trust
+    - POSTGRES_USER=postgress
+    - POSTGRES_DB=jabref
+    command: " postgres -c listen_addresses=* "
+    command: " postgres -c port=5432 "
+    volumes:
+          - ./data/db:/var/lib/postgresql/data
+
+  jabref-online:
+    build:
+      context: .
+    image: ghcr.io/jabref/jabrefonline:latest
+    container_name: jabref-online
+    hostname: jabref-chatbot
+    environment:
+      - PORT=3560
+    ports:
+      - 3560:3560

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,31 @@
+FROM node:14-alpine As development
+
+WORKDIR /app
+
+COPY package*.json ./
+COPY yarn.lock ./
+
+RUN yarn install
+
+COPY . .
+RUN yarn generate
+
+RUN yarn build
+
+
+FROM node:14-alpine as production
+
+ARG NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV}
+
+WORKDIR /app
+
+COPY package*.json ./
+COPY yarn.lock ./
+RUN yarn install --only=production --pure-lockfile
+
+COPY . .
+
+COPY --from=development /app/dist ./dist
+
+CMD ["yarn", "start"]

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "lint": "yarn lint:js && yarn lint:graphql",
     "lint:js": "eslint --ext .ts,.js,.vue --ignore-path .gitignore .",
     "lint:graphql": "cross-env TS_NODE_PROJECT=./tsconfig.cjs.json eslint --ext .graphql,.vue --ignore-path .gitignore .",
-    "postinstall": "yarn generate",
     "test": "jest --runInBand",
     "test:integration": "jest integration.test.ts --runInBand",
     "test:unit": "jest spec.ts",
@@ -83,7 +82,9 @@
     "typescript": "^4.3.5",
     "vue-apollo": "^3.0.7",
     "vue-tailwind": "^2.4.2",
-    "vue-tree-list": "^1.5.0"
+    "vue-tree-list": "^1.5.0",
+    "skip-postinstall": "^1.0.0"
+
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",


### PR DESCRIPTION
I am tying to build JabRef Online as docker container, However, currently it's not building because the redis is not running at build time. I really wonder why nuxt build accesses the redis at build time.

The only thing I found is this issue from another user https://github.com/nuxt/nuxt.js/issues/6933 but I don't see how this helps here

```
 > [development 8/8] RUN yarn build:
#14 0.464 yarn run v1.22.5
#14 0.640 $ nuxt build
#14 1.111 
#14 1.111  WARN  css-loader@3.6.0 is installed but >=4.2.0 is expected
#14 1.111 
#14 2.411 ℹ Merging Tailwind config from ~/tailwind.config.js
#14 6.029 events.js:377
#14 6.029       throw er; // Unhandled 'error' event
#14 6.029       ^
#14 6.029 
#14 6.029 Error: connect ECONNREFUSED 127.0.0.1:6380
#14 6.029     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1148:16)
#14 6.029 Emitted 'error' event on RedisClient instance at:
#14 6.029     at RedisClient.on_error (/app/node_modules/redis/index.js:342:14)
#14 6.029     at TLSSocket.<anonymous> (/app/node_modules/redis/index.js:223:14)
#14 6.029     at TLSSocket.emit (events.js:400:28)
#14 6.029     at emitErrorNT (internal/streams/destroy.js:106:8)
#14 6.029     at emitErrorCloseNT (internal/streams/destroy.js:74:3)
#14 6.029     at processTicksAndRejections (internal/process/task_queues.js:82:21) {
#14 6.029   errno: -111,
#14 6.029   code: 'ECONNREFUSED',
#14 6.029   syscall: 'connect',
#14 6.029   address: '127.0.0.1',
#14 6.029   port: 6380
#14 6.029 }
#14 6.071 error Command failed with exit code 1.
#14 6.071 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
------
failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c yarn build]: exit code: 1
```