### PR TITLE
Deploy api/server on Azure

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-pebble-0224c3803.yml
+++ b/.github/workflows/azure-static-web-apps-mango-pebble-0224c3803.yml
@@ -23,9 +23,6 @@ jobs:
           # This is needed correctly deploy the Azure Functions (API)
           mkdir -p .output/server
           touch .output/server/.gitkeep
-          # And this to generate the correct Azure Static Web App config
-          yarn install
-          NITRO_PRESET=azure yarn build
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/azure-static-web-apps-mango-pebble-0224c3803.yml
+++ b/.github/workflows/azure-static-web-apps-mango-pebble-0224c3803.yml
@@ -18,6 +18,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Prepare
+        run:
+          # This is needed correctly deploy the Azure Functions (API)
+          mkdir -p .output/server
+          touch .output/server/.gitkeep
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/azure-static-web-apps-mango-pebble-0224c3803.yml
+++ b/.github/workflows/azure-static-web-apps-mango-pebble-0224c3803.yml
@@ -19,10 +19,13 @@ jobs:
         with:
           submodules: true
       - name: Prepare
-        run:
+        run: |
           # This is needed correctly deploy the Azure Functions (API)
           mkdir -p .output/server
           touch .output/server/.gitkeep
+          # And this to generate the correct Azure Static Web App config
+          yarn install
+          NITRO_PRESET=azure yarn build
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ typings/
 .nuxt/
 .output/
 dist/
+staticwebapp.config.json
 
 # Gatsby files
 .cache/

--- a/plugins/apollo.ts
+++ b/plugins/apollo.ts
@@ -17,7 +17,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   if (config.public.environment === Environment.LocalDevelopment) {
     httpLink = new HttpLink({ uri: 'http://localhost:3000/api', fetch })
   } else {
-    httpLink = new HttpLink({ uri: 'http://0.0.0.0:8080/api', fetch })
+    httpLink = new HttpLink({ uri: '/api', fetch })
   }
 
   // Print errors


### PR DESCRIPTION
Deployment ignores the server/api part, since it doesn't exist at the beginning. So use the workaround mentioned at https://nitro.unjs.io/deploy/providers/azure.html#deploy-from-ci-cd-via-github-actions