### PR TITLE
Migrate to h3 server

### DIFF
--- a/apollo/apollo-server.ts
+++ b/apollo/apollo-server.ts
@@ -1,0 +1,72 @@
+import type { ServerResponse } from 'http'
+import {
+  useBody,
+  useQuery,
+  IncomingMessage,
+  CompatibilityEvent,
+  sendError,
+  EventHandler,
+} from 'h3'
+import type { GraphQLOptions } from 'apollo-server-core'
+import {
+  ApolloServerBase,
+  convertNodeHttpToRequest,
+  runHttpQuery,
+} from 'apollo-server-core'
+
+// Originally taken from https://github.com/newbeea/nuxt3-apollo-starter/blob/master/server/graphql/apollo-server.ts
+// TODO: Implement health check https://github.com/apollographql/apollo-server/blob/main/docs/source/monitoring/health-checks.md
+// TODO: Implement landing page
+export class ApolloServer extends ApolloServerBase {
+  async createGraphQLServerOptions(
+    request?: IncomingMessage,
+    reply?: ServerResponse
+  ): Promise<GraphQLOptions> {
+    return this.graphQLServerOptions({ request, reply })
+  }
+
+  createHandler(): EventHandler {
+    return async (event: CompatibilityEvent) => {
+      const options = await this.createGraphQLServerOptions(
+        event.req,
+        event.res
+      )
+      try {
+        const { graphqlResponse, responseInit } = await runHttpQuery([], {
+          method: event.req.method || 'GET',
+          options,
+          query:
+            event.req.method === 'POST'
+              ? await useBody(event)
+              : useQuery(event),
+          request: convertNodeHttpToRequest(event.req),
+        })
+        if (responseInit.headers) {
+          for (const [name, value] of Object.entries<string>(
+            responseInit.headers
+          ))
+            event.res.setHeader(name, value)
+        }
+        event.res.statusCode = responseInit.status || 200
+        return graphqlResponse
+      } catch (error: any) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (error.headers) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          for (const [name, value] of Object.entries<string>(error.headers))
+            event.res.setHeader(name, value)
+        }
+        sendError(
+          event,
+          createError({
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+            statusCode: error.statusCode || 500,
+            statusMessage: (error as Error).message,
+          })
+        )
+      }
+    }
+  }
+}
+
+export default ApolloServer

--- a/server/index.ts
+++ b/server/index.ts
@@ -71,5 +71,7 @@ export default defineLazyEventHandler(async () => {
   })
 
   await server.start()
-  return server.createHandler()
+  return server.createHandler({
+    path: '/api',
+  })
 })

--- a/server/index.ts
+++ b/server/index.ts
@@ -44,6 +44,7 @@ http.OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
 }
 
 const app = createApp()
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
 const httpServer = http.createServer(app)
 
 export default defineLazyEventHandler(async () => {

--- a/server/user/passport-initializer.ts
+++ b/server/user/passport-initializer.ts
@@ -1,5 +1,5 @@
 import connectRedis from 'connect-redis'
-import { Express } from 'express-serve-static-core'
+import { App } from 'h3'
 import session from 'express-session'
 import passport from 'passport'
 import { RedisClientType } from 'redis'
@@ -25,7 +25,7 @@ export default class PassportInitializer {
     )
   }
 
-  install(app: Express): void {
+  install(app: App): void {
     const config = useRuntimeConfig()
 
     // TODO: Use redis store also for development as soon as https://github.com/tj/connect-redis/issues/336 is fixed (and mock-redis is compatible with redis v4)

--- a/server/user/passport-initializer.ts
+++ b/server/user/passport-initializer.ts
@@ -43,6 +43,7 @@ export default class PassportInitializer {
     // Add middleware that sends and receives the session ID using cookies
     // See https://github.com/expressjs/session#readme
     app.use(
+      // @ts-ignore: https://github.com/unjs/h3/issues/146
       session({
         store,
         // The secret used to sign the session cookie
@@ -64,6 +65,7 @@ export default class PassportInitializer {
       })
     )
     // Add passport as middleware (this more or less only adds the _passport variable to the request)
+    // @ts-ignore: https://github.com/unjs/h3/issues/146
     app.use(passport.initialize())
     // Add middleware that authenticates request based on the current session state (i.e. we alter the request to contain the hydrated user object instead of only the session ID)
     app.use(passport.session())


### PR DESCRIPTION
Examples:
- https://github.com/lewebsimple/apollo-server-h3/blob/main/src/ApolloServer.ts
- https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-azure-functions/src/azureFunctionApollo.ts
- https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-micro/src/ApolloServer.ts
- https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-hapi/src/ApolloServer.ts

Follow-up:
- https://github.com/unjs/h3/issues/146
- Exception: this.socket.destroy is not a function
Stack: TypeError: this.socket.destroy is not a function
    at IncomingMessage.destroy (_http_incoming.js:130:17)
    at file:///home/site/wwwroot/functions/node_modules/unenv/runtime/fetch/call.mjs:20:11
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async Module.handle (file:///home/site/wwwroot/functions/chunks/nitro/azure.mjs:1662:49) 