### PR TITLE
Run PR workflow against PR code and not main branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     interval: "monthly"
   labels:
     - "type: dependencies"
+    - "status: safe to test"
 
 # Fetch and update latest `github-actions` pkgs
 - package-ecosystem: github-actions
@@ -18,3 +19,4 @@ updates:
     interval: "monthly"
   labels:
     - "type: dependencies"
+    - "status: safe to test"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request_target:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened, closed, labeled]
     branches:
       - main
 
@@ -15,11 +15,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    if: github.event_name == 'pull_request_target' && github.event.action != 'closed'
+    if: github.event_name == 'pull_request_target' && github.event.action != 'closed' && (contains(github.event.pull_request.labels.*.name, 'status: safe to test'))
     
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Prepare
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    if: github.event_name == 'pull_request_target' && github.event.action != 'closed' && (contains(github.event.pull_request.labels.*.name, 'status: safe to test'))
+    if: "github.event_name == 'pull_request_target' && github.event.action != 'closed' && (contains(github.event.pull_request.labels.*.name, 'status: safe to test') || github.event.pull_request_target.user.login == 'tobiasdiez')"
     
     steps:
       - name: Checkout


### PR DESCRIPTION
Using the recommendation from https://securitylab.github.com/research/github-actions-preventing-pwn-requests/. In short, `pull_request_target` uses the context of the main branch, in particular, checkout gives the code of the main branch.

Using the code from the PR is in general unsafe, thus we need to mark the PR with the "safe to test" label.