### PR TITLE
Fix build and exceptions on azure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ jobs:
           app_location: '/' # App source code path
           api_location: '.output/server' # Api source code path - optional
           output_location: '.output/public' # Built app content directory - optional
+          app_build_command: 'yarn build:azure'
           ###### End of Repository/Build Configurations ######
         env:
           DATABASE_URL: ${{ secrets.AZURE_TEST_DATABASE_URL }}
@@ -122,6 +123,7 @@ jobs:
           app_location: '/' # App source code path
           api_location: '.output/server' # Api source code path - optional
           output_location: '.output/public' # Built app content directory - optional
+          app_build_command: 'yarn build:azure'
           ###### End of Repository/Build Configurations ######
 
       - name: Run API tests

--- a/.yarn/patches/express-session-npm-1.17.3-0819dbe06c.patch
+++ b/.yarn/patches/express-session-npm-1.17.3-0819dbe06c.patch
@@ -1,0 +1,16 @@
+diff --git a/index.js b/index.js
+index 40a442baf2fec2c6bdce79a5fba5086b5b8aac07..321ddabde7361d6ce6b5da450af1be4d6caf3017 100644
+--- a/index.js
++++ b/index.js
+@@ -273,7 +273,10 @@ function session(options) {
+         }
+ 
+         if (!res._header) {
+-          res._implicitHeader()
++          // CHANGED: Workaround for issue with Azure deploy: https://github.com/unjs/nitro/issues/351
++          // Original code taken from https://github.com/nodejs/node/blob/main/lib/_http_server.js
++          res.writeHead(res.statusCode)
++          // res._implicitHeader()
+         }
+ 
+         if (chunk == null) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --runInBand",
     "test:integration": "cross-env NODE_OPTIONS=--experimental-vm-modules jest test.ts --runInBand",
     "test:unit": "cross-env NODE_OPTIONS=--experimental-vm-modules jest spec.ts",
-    "test:api": "newman run server/postman/TestSuite.json '$@' && newman run server/postman/TestSuiteLoggedIn.json '$@'",
+    "test:api": "newman run server/postman/TestSuite.json $@ && newman run server/postman/TestSuiteLoggedIn.json $@",
     "typecheck": "nuxi typecheck",
     "validate": "yarn graphql:validate"
   },

--- a/package.json
+++ b/package.json
@@ -158,7 +158,8 @@
     "ufo": "^0.8.4",
     "parse-entities": "^4.0.0",
     "unist-builder": "^3.0.0",
-    "remark-parse": "^10.0.1"
+    "remark-parse": "^10.0.1",
+    "express-session@^1.17.3": "patch:express-session@npm%3A1.17.3#./.yarn/patches/express-session-npm-1.17.3-0819dbe06c.patch"
   },
   "resolutionsComments": {
     "@graphql-tools/mock": "Can be removed once apollo-server updated its dependencies: https://github.com/apollographql/apollo-server/issues/5901",

--- a/server/index.ts
+++ b/server/index.ts
@@ -84,8 +84,8 @@ http.IncomingMessage.Readable.prototype.unpipe = function (dest) {
 // Original code taken from https://github.com/nodejs/node/blob/main/lib/_http_server.js
 // @ts-ignore: Is workaround anyway
 http.ServerResponse.prototype._implicitHeader = function _implicitHeader() {
-  this.writeHead(this.statusCode);
-};
+  this.writeHead(this.statusCode)
+}
 
 export default defineLazyEventHandler(async () => {
   const server = new ApolloServer({

--- a/server/index.ts
+++ b/server/index.ts
@@ -82,7 +82,8 @@ http.IncomingMessage.Readable.prototype.unpipe = function (dest) {
 
 // Workaround for issue with Azure deploy: https://github.com/unjs/nitro/issues/351
 // Original code taken from https://github.com/nodejs/node/blob/main/lib/_http_server.js
-ServerResponse.prototype._implicitHeader = function _implicitHeader() {
+// @ts-ignore: Is workaround anyway
+http.ServerResponse.prototype._implicitHeader = function _implicitHeader() {
   this.writeHead(this.statusCode);
 };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -80,6 +80,12 @@ http.IncomingMessage.Readable.prototype.unpipe = function (dest) {
   return this
 }
 
+// Workaround for issue with Azure deploy: https://github.com/unjs/nitro/issues/351
+// Original code taken from https://github.com/nodejs/node/blob/main/lib/_http_server.js
+ServerResponse.prototype._implicitHeader = function _implicitHeader() {
+  this.writeHead(this.statusCode);
+};
+
 export default defineLazyEventHandler(async () => {
   const server = new ApolloServer({
     schema: await loadSchemaWithResolvers(),

--- a/server/index.ts
+++ b/server/index.ts
@@ -80,13 +80,6 @@ http.IncomingMessage.Readable.prototype.unpipe = function (dest) {
   return this
 }
 
-// Workaround for issue with Azure deploy: https://github.com/unjs/nitro/issues/351
-// Original code taken from https://github.com/nodejs/node/blob/main/lib/_http_server.js
-// @ts-ignore: Is workaround anyway
-http.ServerResponse.prototype._implicitHeader = function _implicitHeader() {
-  this.writeHead(this.statusCode)
-}
-
 export default defineLazyEventHandler(async () => {
   const server = new ApolloServer({
     schema: await loadSchemaWithResolvers(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -12709,7 +12709,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express-session@npm:^1.17.3":
+"express-session@npm:1.17.3":
   version: 1.17.3
   resolution: "express-session@npm:1.17.3"
   dependencies:
@@ -12722,6 +12722,22 @@ __metadata:
     safe-buffer: 5.2.1
     uid-safe: ~2.1.5
   checksum: 1021a793433cbc6a1b32c803fcb2daa1e03a8f50dd907e8745ae57994370315a5cfde5b6ef7b062d9a9a0754ff268844bda211c08240b3a0e01014dcf1073ec5
+  languageName: node
+  linkType: hard
+
+"express-session@patch:express-session@npm%3A1.17.3#./.yarn/patches/express-session-npm-1.17.3-0819dbe06c.patch::locator=jabref-online%40workspace%3A.":
+  version: 1.17.3
+  resolution: "express-session@patch:express-session@npm%3A1.17.3#./.yarn/patches/express-session-npm-1.17.3-0819dbe06c.patch::version=1.17.3&hash=50cc05&locator=jabref-online%40workspace%3A."
+  dependencies:
+    cookie: 0.4.2
+    cookie-signature: 1.0.6
+    debug: 2.6.9
+    depd: ~2.0.0
+    on-headers: ~1.0.2
+    parseurl: ~1.3.3
+    safe-buffer: 5.2.1
+    uid-safe: ~2.1.5
+  checksum: 90365cd1657a6491b28f829e28e87f636dfd5d527a1420e5c2e573334ddf31e71637f273693b1558a1eae1c50f5ee4b0ea2aedb526e4cd7599e781297f007795
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Towards fixing https://github.com/JabRef/JabRefOnline/issues/1285

Fix 
> LanguageWorkerConsoleLog[error] Worker d515a7ff-9c85-424a-9dbb-7ad7c02d98e8 uncaught exception (learn more: https://go.microsoft.com/fwlink/?linkid=2097909 ): TypeError: res._implicitHeader is not a function     at writetop (/home/site/wwwroot/functions/node_modules/express-session/index.js:276:15)     at ServerResponse.end (/home/site/wwwroot/functions/node_modules/express-session/index.js:343:16)     at Immediate.<anonymous> (file:///home/site/wwwroot/functions/node_modules/h3/dist/index.mjs:138:17)     at processImmediate (internal/timers.js:464:21)

and fixes (hopefully) that azure builds two app instances by running `yarn build` and `yarn build:azure`

Followup https://github.com/JabRef/JabRefOnline/issues/1335