### PR TITLE
Fix dependabot yarn 2 support

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,66 @@
+# Automatically save updated `yarn.lock` file for dependabot PRs.
+# This is necessary because dependabot doesn't support Yarn v2 yet:
+# https://github.com/dependabot/dependabot-core/issues/1297
+#
+# Note: We use the `pull_request_target` event due to GitHub security measures.
+#       It is important to ensure we don't execute any untrusted PR code in this context.
+# See: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+#      https://securitylab.github.com/research/github-actions-preventing-pwn-requests
+
+# Inspired from https://gist.github.com/amacneil/60bf679f357bad9d62103cfdc86cbd74
+name: Dependabot
+on:
+  - pull_request_target
+
+jobs:
+  fix-lockfile:
+    runs-on: ubuntu-latest
+    if: |
+      github.actor == 'dependabot[bot]' &&
+      contains(github.event.pull_request.head.ref, 'dependabot/npm_and_yarn/')
+
+    # IMPORTANT: setting YARN_ENABLE_SCRIPTS=false is critical to ensure that untrusted
+    # PRs can't add an npm package and then use that to execute untrusted code in
+    # a trusted context. See links at the top of this workflow for further details.
+    # See also: https://github.com/yarnpkg/berry/issues/1679#issuecomment-669937860
+    env:
+      YARN_ENABLE_SCRIPTS: false
+      YARN_ENABLE_IMMUTABLE_INSTALLS: false
+
+    steps:
+      - uses: actions/checkout@v2.3.5
+        with:
+          # Using a Personal Access Token here is required to trigger workflows on our new commit.
+          # The default GitHub token doesn't trigger any workflows.
+          # See: https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854/2
+          token: ${{ secrets.DEPENDABOT_PAT }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 2
+
+      - run: git lfs pull --include .yarn/
+
+      - name: Setup node
+        uses: actions/setup-node@v2.4.1
+        with:
+          node-version: 16.x
+
+      - name: Restore cache
+        uses: actions/cache@v2.1.4
+        with:
+          path: .yarn/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn-
+
+      - run: git checkout HEAD~1 yarn.lock
+
+      - run: yarn install --mode=skip-build
+
+      - run: yarn dedupe
+
+      - name: Commit yarn.lock
+        run: |
+          git config user.name "dependabot-fix"
+          git config user.email "dependabot-fix@example.com"
+          git add yarn.lock
+          git commit -m '[dependabot skip] Fix yarn.lock'
+          git push


### PR DESCRIPTION
Workaround for https://github.com/dependabot/dependabot-core/issues/1297

Taken from https://blog.alphasmanifesto.com/2021/11/07/yarn-2-dependabot/