### PR TITLE
Dependabot fix: don't run install scripts

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -55,7 +55,7 @@ jobs:
 
       - run: yarn install --mode=skip-build
 
-      - run: yarn dedupe
+      - run: yarn dedupe --mode=update-lockfile
 
       - name: Commit yarn.lock
         run: |


### PR DESCRIPTION
For better performance and if postinstalls fails