### PR TITLE
Fix storybook dev command

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prisma:studio": "prisma studio",
     "prisma:generate": "prisma generate",
     "prisma:generate:watch": "prisma generate --watch",
-    "storybook": "start-storybook -p 6006 --preview-url=http://localhost:3000/_storybook/external-iframe --no-manager-cache",
+    "storybook": "cross-env NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006 --preview-url=http://localhost:3000/_storybook/external-iframe --no-manager-cache",
     "storybook:build": "build-storybook",
     "storybook:publish": "chromatic --exit-zero-on-changes --build-script-name storybook:build",
     "graphql:generate": "graphql-codegen-esm",


### PR DESCRIPTION
Workaround for https://github.com/storybookjs/storybook/issues/16555. The error "Error: error:0308010C:digital envelope routines::unsupported" is fixed with webpack 5, but storybook still uses webpack 4.