### PR TITLE
Use fragment masking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ apollo/gql.ts
 apollo/graphql.ts
 apollo/index.ts
 apollo/introspection.ts
+apollo/fragment-masking.ts
 
 # Yarn: https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
 .pnp.*

--- a/components/DocumentEditor.vue
+++ b/components/DocumentEditor.vue
@@ -102,7 +102,7 @@
         class="mt-4 mb-1"
       ></document-editor-header>
       <t-table
-        :data="external"
+        :data="externalLinks"
         variant="plain"
         class="text-sm"
       ></t-table>
@@ -110,12 +110,12 @@
   </div>
 </template>
 
-<script lang="ts">
-import { useQuery, useResult } from '@vue/apollo-composable'
-import { gql } from '~/apollo'
+<script lang="ts" setup>
+import { useQuery } from '@vue/apollo-composable'
+import { gql, useFragment } from '~/apollo'
 import Tags from './tagify.vue'
 
-export const DocumentDetails = gql(/* GraphQL */ `
+const DocumentDetails = gql(/* GraphQL */ `
   fragment DocumentDetails on Document {
     id
     title
@@ -159,141 +159,128 @@ export const DocumentDetails = gql(/* GraphQL */ `
   }
 `)
 
-export default defineComponent({
-  components: {
-    Tags,
+const props = defineProps({
+  documentId: {
+    type: String,
+    required: true,
   },
-  props: {
-    documentId: {
-      type: String,
-      required: true,
-    },
-  },
-  setup(props) {
-    const { result } = useQuery(
-      gql(/* GraphQL */ `
-        query GetDocumentDetails($documentId: ID!) {
-          userDocument(id: $documentId) {
-            ...DocumentDetails
-          }
-        }
-      `),
-      () => ({
-        documentId: props.documentId,
-      })
-    )
-    const document = useResult(result)
+})
 
-    const authors = computed({
-      get: () =>
-        document.value?.authors.map((author) => ({
-          value: author.name,
-        })),
-      set: (value) => {
-        // TODO: implement
-      },
-    })
-    const authorSuggestions = [{ value: 'Linus' }]
-
-    const keywords = computed({
-      get: () =>
-        document.value?.keywords.map((keyword) => ({
-          value: keyword,
-        })),
-      set: (value) => {
-        // TODO: implement
-      },
-    })
-    const keywordSuggestions = [{ value: 'Differential Geometry' }]
-
-    const groups = [{ value: 'Chocolate Making' }, { value: 'Consumption' }]
-    const groupSuggestions = [{ value: 'Grinding' }]
-
-    const external = computed(() => [
-      { name: 'DOI', value: document.value?.doi },
-      { name: 'ArXiv', value: '1812.04695' },
-      { name: 'MathSciNet', value: 'MR3997558' },
-    ])
-
-    return {
-      title: computed({
-        get: () => document.value?.title,
-        set: (value) => {
-          // TODO: implement
-        },
-      }),
-      authors,
-      authorSuggestions,
-      published: computed({
-        get: () =>
-          document.value && 'published' in document.value
-            ? document.value.published
-            : null,
-        set: (value) => {
-          // TODO: implement
-        },
-      }),
-      journal: computed({
-        get: () =>
-          document.value &&
-          'in' in document.value &&
-          document.value.in &&
-          'journal' in document.value.in
-            ? document.value.in?.journal?.name
-            : null,
-        set: (value) => {
-          // TODO: implement
-        },
-      }),
-      volume: computed({
-        get: () =>
-          document.value &&
-          'in' in document.value &&
-          document.value.in &&
-          'volume' in document.value.in
-            ? document.value.in?.volume
-            : null,
-        set: (value) => {
-          // TODO: implement
-        },
-      }),
-      issue: computed({
-        get: () =>
-          document.value &&
-          'in' in document.value &&
-          document.value.in &&
-          'number' in document.value.in
-            ? document.value.in?.number
-            : null,
-        set: (value) => {
-          // TODO: implement
-        },
-      }),
-      pages: computed({
-        get: () =>
-          document.value && 'pageStart' in document.value
-            ? (document.value.pageStart ?? '') +
-              (document.value.pageEnd ? '-' + document.value.pageEnd : '')
-            : null,
-        set: (value) => {
-          // TODO: implement
-        },
-      }),
-      abstract: computed({
-        get: () =>
-          document.value && 'abstract' in document.value
-            ? document.value.abstract
-            : null,
-        set: (value) => {
-          // TODO: implement
-        },
-      }),
-      keywords,
-      keywordSuggestions,
-      groups,
-      groupSuggestions,
-      external,
+const { result } = useQuery(
+  gql(/* GraphQL */ `
+    query GetDocumentDetails($documentId: ID!) {
+      userDocument(id: $documentId) {
+        ...DocumentDetails
+      }
     }
+  `),
+  () => ({
+    documentId: props.documentId,
+  })
+)
+const document = computed(() =>
+  useFragment(DocumentDetails, result.value?.userDocument)
+)
+
+const authors = computed({
+  get: () =>
+    document.value?.authors.map((author) => ({
+      value: author.name,
+    })),
+  set: (value) => {
+    // TODO: implement
+  },
+})
+const authorSuggestions = [{ value: 'Linus' }]
+
+const keywords = computed({
+  get: () =>
+    document.value?.keywords.map((keyword) => ({
+      value: keyword,
+    })),
+  set: (value) => {
+    // TODO: implement
+  },
+})
+const keywordSuggestions = [{ value: 'Differential Geometry' }]
+
+const groups = [{ value: 'Chocolate Making' }, { value: 'Consumption' }]
+const groupSuggestions = [{ value: 'Grinding' }]
+
+const externalLinks = computed(() => [
+  { name: 'DOI', value: document.value?.doi },
+  { name: 'ArXiv', value: '1812.04695' },
+  { name: 'MathSciNet', value: 'MR3997558' },
+])
+
+const title = computed({
+  get: () => document.value?.title,
+  set: (value) => {
+    // TODO: implement
+  },
+})
+const published = computed({
+  get: () =>
+    document.value && 'published' in document.value
+      ? document.value.published
+      : null,
+  set: (value) => {
+    // TODO: implement
+  },
+})
+const journal = computed({
+  get: () =>
+    document.value &&
+    'in' in document.value &&
+    document.value.in &&
+    'journal' in document.value.in
+      ? document.value.in?.journal?.name
+      : null,
+  set: (value) => {
+    // TODO: implement
+  },
+})
+const volume = computed({
+  get: () =>
+    document.value &&
+    'in' in document.value &&
+    document.value.in &&
+    'volume' in document.value.in
+      ? document.value.in?.volume
+      : null,
+  set: (value) => {
+    // TODO: implement
+  },
+})
+const issue = computed({
+  get: () =>
+    document.value &&
+    'in' in document.value &&
+    document.value.in &&
+    'number' in document.value.in
+      ? document.value.in?.number
+      : null,
+  set: (value) => {
+    // TODO: implement
+  },
+})
+const pages = computed({
+  get: () =>
+    document.value && 'pageStart' in document.value
+      ? (document.value.pageStart ?? '') +
+        (document.value.pageEnd ? '-' + document.value.pageEnd : '')
+      : null,
+  set: (value) => {
+    // TODO: implement
+  },
+})
+const abstract = computed({
+  get: () =>
+    document.value && 'abstract' in document.value
+      ? document.value.abstract
+      : null,
+  set: (value) => {
+    // TODO: implement
   },
 })
 </script>

--- a/components/DocumentView.vue
+++ b/components/DocumentView.vue
@@ -11,7 +11,7 @@
           class="mr-1"
           :title="typeDescription"
         ></FontAwesomeIcon>
-        <span>{{ source.title }}</span>
+        <span>{{ document.title }}</span>
       </button>
       <!-- TOOD: Add citation display
       <a
@@ -23,11 +23,11 @@
       -->
     </div>
     <div
-      v-if="'authors' in source && source.authors"
+      v-if="'authors' in document && document.authors"
       class="space-x-3"
     >
       <span
-        v-for="author in source.authors"
+        v-for="author in document.authors"
         :key="author.id"
         >{{ author.name }}</span
       >
@@ -36,29 +36,29 @@
       <span class="font-semibold">2019</span>
       <a
         v-if="
-          'in' in source &&
-          source.in &&
-          'journal' in source.in &&
-          source.in.journal
+          'in' in document &&
+          document.in &&
+          'journal' in document.in &&
+          document.in.journal
         "
-        :href="'journal/' + source.in.journal.id"
-        >{{ source.in.journal.name }}</a
+        :href="'journal/' + document.in.journal.id"
+        >{{ document.in.journal.name }}</a
       >
       <a
-        v-if="'institution' in source && source.institution"
-        :href="'institution/' + source.institution.id"
-        >{{ source.institution.name }}</a
+        v-if="'institution' in document && document.institution"
+        :href="'institution/' + document.institution.id"
+        >{{ document.institution.name }}</a
       >
-      <span v-if="'in' in source && source.in && 'title' in source.in">
-        {{ source.in.title }}
+      <span v-if="'in' in document && document.in && 'title' in document.in">
+        {{ document.in.title }}
       </span>
     </div>
     <div
-      v-if="source.keywords.length > 0"
+      v-if="document.keywords.length > 0"
       class="flex flex-row space-x-2 text-sm"
     >
       <t-tag
-        v-for="keyword in source.keywords"
+        v-for="keyword in document.keywords"
         :key="keyword"
         variant="badge"
         class="border border-gray-400"
@@ -73,12 +73,12 @@
       </n-button>
       -->
     </div>
-    <div v-if="'abstract' in source && source.abstract">
+    <div v-if="'abstract' in document && document.abstract">
       <span
         class="grow"
         :class="{ 'line-clamp-2': !viewFullAbstract }"
       >
-        {{ source.abstract }}
+        {{ document.abstract }}
       </span>
       <n-button
         text
@@ -104,12 +104,12 @@
   </div>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import type { PropType } from 'vue'
-import { DocumentType, gql } from '~/apollo'
+import { FragmentType, gql, useFragment } from '~/apollo'
 import { useUiStore } from '~/store'
 
-export const DocumentForView = gql(/* GraphQL */ `
+const DocumentForView = gql(/* GraphQL */ `
   fragment DocumentForView on Document {
     id
     title
@@ -147,54 +147,44 @@ export const DocumentForView = gql(/* GraphQL */ `
   }
 `)
 
-export default defineComponent({
-  props: {
-    source: {
-      type: Object as PropType<DocumentType<typeof DocumentForView>>,
-      required: true,
-    },
-  },
-  setup(props) {
-    const { source: document } = toRefs(props)
-    const viewFullAbstract = ref(false)
-
-    const typeIcon = computed(() => {
-      switch (document.value.__typename) {
-        case 'JournalArticle':
-          return 'newspaper'
-        case 'ProceedingsArticle':
-          return 'chalkboard-teacher'
-        case 'Thesis':
-          return 'graduation-cap'
-        default:
-          return 'file-alt'
-      }
-    })
-
-    const typeDescription = computed(() => {
-      switch (document.value.__typename) {
-        case 'JournalArticle':
-          return 'Journal Paper'
-        case 'ProceedingsArticle':
-          return 'Conference Paper'
-        case 'Thesis':
-          return 'PhD Thesis'
-        default:
-          return document.value.__typename
-      }
-    })
-
-    const ui = useUiStore()
-    function displayDocumentDetails() {
-      ui.displayDocumentDetails(document.value.id)
-    }
-
-    return {
-      typeIcon,
-      typeDescription,
-      viewFullAbstract,
-      displayDocumentDetails,
-    }
+const props = defineProps({
+  source: {
+    type: Object as PropType<FragmentType<typeof DocumentForView>>,
+    required: true,
   },
 })
+
+const document = computed(() => useFragment(DocumentForView, props.source))
+const viewFullAbstract = ref(false)
+
+const typeIcon = computed(() => {
+  switch (document.value.__typename) {
+    case 'JournalArticle':
+      return 'newspaper'
+    case 'ProceedingsArticle':
+      return 'chalkboard-teacher'
+    case 'Thesis':
+      return 'graduation-cap'
+    default:
+      return 'file-alt'
+  }
+})
+
+const typeDescription = computed(() => {
+  switch (document.value.__typename) {
+    case 'JournalArticle':
+      return 'Journal Paper'
+    case 'ProceedingsArticle':
+      return 'Conference Paper'
+    case 'Thesis':
+      return 'PhD Thesis'
+    default:
+      return document.value.__typename
+  }
+})
+
+const ui = useUiStore()
+function displayDocumentDetails() {
+  ui.displayDocumentDetails(document.value.id)
+}
 </script>

--- a/graphql.config.json
+++ b/graphql.config.json
@@ -33,6 +33,9 @@
             "./apollo/cache.ts"
           ],
           "preset": "gql-tag-operations-preset",
+          "presetConfig": {
+            "fragmentMasking": true
+          },
           "config": {
             "scalars": {
               "Date": "Date",

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -53,6 +53,7 @@ const { result, fetchMore } = useQuery(
         ) {
           edges {
             node {
+              id
               ...DocumentForView
             }
           }


### PR DESCRIPTION
In order to fully encapsulate the data that each component need, i.e. not even the parent knows what data the child needs.

See https://www.the-guild.dev/graphql/codegen/plugins/gql-tag-operations-preset#fragment-masking

Fixes #873