### PR TITLE
chore: remove obsolete ts-ignore in generated apollo file

### DIFF
--- a/graphql.config.json
+++ b/graphql.config.json
@@ -29,14 +29,7 @@
           "plugins": ["fragment-matcher"]
         },
         "apollo/validation.internal.ts": {
-          "plugins": [
-            {
-              "add": {
-                "content": "// @ts-nocheck"
-              }
-            },
-            "typescript-validation-schema"
-          ],
+          "plugins": ["typescript-validation-schema"],
           "config": {
             "schema": "zod",
             "scalarSchemas": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
   },
   "devDependencies": {
     "@azure/static-web-apps-cli": "^1.0.3",
-    "@graphql-codegen/add": "^3.2.3",
     "@graphql-codegen/cli": "^2.16.5",
     "@graphql-codegen/fragment-matcher": "^3.3.3",
     "@graphql-codegen/gql-tag-operations-preset": "^1.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16051,7 +16051,6 @@ __metadata:
     "@fortawesome/fontawesome-svg-core": ^6.2.1
     "@fortawesome/free-solid-svg-icons": ^6.2.1
     "@fortawesome/vue-fontawesome": ^3.0.2
-    "@graphql-codegen/add": ^3.2.3
     "@graphql-codegen/cli": ^2.16.5
     "@graphql-codegen/fragment-matcher": ^3.3.3
     "@graphql-codegen/gql-tag-operations-preset": ^1.7.3


### PR DESCRIPTION
Now that https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema/issues/252 is fixed.