### PR TITLE
chore: remove github copilot from recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,12 +1,11 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "github.copilot",
     "streetsidesoftware.code-spell-checker",
     "github.vscode-pull-request-github",
     "eamodio.gitlens",
     "graphql.vscode-graphql",
-    "ZixuanChen.vitest-explorer",
+    "zixuanchen.vitest-explorer",
     "esbenp.prettier-vscode",
     "prisma.prisma",
     "bradlc.vscode-tailwindcss",


### PR DESCRIPTION
Reason: we don't really need it (and I'm using the insider version of it)