### PR TITLE
chore: remove obsolete prerender exception

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -173,8 +173,6 @@ export default defineNuxtConfig({
     '/bluehat2022': { redirect: '/codeprojects/bluehat2022' },
     '/surveys/': { redirect: '/surveys/2015' },
     '/': { prerender: true },
-    // TODO: Workaround for https://github.com/unjs/nitro/issues/1402
-    '/download': { prerender: false },
   },
 
   /**


### PR DESCRIPTION
now that https://github.com/unjs/nitro/issues/1402 and https://github.com/unjs/nitro/issues/1418 are fixed.