### PR TITLE
chore: run deployment on dependabot PRs without label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,6 @@ updates:
     open-pull-requests-limit: 20
     schedule:
       interval: 'monthly'
-    labels:
-      - 'type: dependencies'
-      - 'status: safe to test'
     commit-message:
       prefix: 'chore'
     groups:
@@ -76,8 +73,5 @@ updates:
     open-pull-requests-limit: 20
     schedule:
       interval: 'monthly'
-    labels:
-      - 'type: dependencies'
-      - 'status: safe to test'
     commit-message:
       prefix: 'chore'

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -30,7 +30,7 @@ jobs:
       # We could also add these checks to a job-wide if condition, to skip the workflow if its unsecure to run.
       # However, Github views skipped workflows as "successful" and thus one could merge a PR without running this workflow first.
       - name: Fail if unsecure
-        if: "github.event_name != 'workflow_dispatch' && !contains(github.event.pull_request.labels.*.name, 'status: safe to test') && github.actor != 'tobiasdiez'"
+        if: "github.event_name != 'workflow_dispatch' && !contains(github.event.pull_request.labels.*.name, 'status: safe to test') && github.actor != 'tobiasdiez' && github.actor != 'dependabot[bot]'"
         run: exit 1
 
       - name: Checkout


### PR DESCRIPTION
Reason: otherwise actions for dependabot PRs are run twice (once for opening, and once for adding the label)