### PR TITLE
feat: make downloads working better for Debian and macOS users

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -77,7 +77,7 @@
                 <ClientOnly>
                   <a
                     class="text-2xl"
-                    :href="constructDownloadUrl()"
+                    href="https://www.fosshub.com/JabRef.html"
                     >Download JabRef</a
                   >
                 </ClientOnly>


### PR DESCRIPTION
Users with a recent Mac (starting from the M1 machines) get the wrong macOS binary. Therefore, raising issues in JabRef repo again and again and binding our spare development resources. - Example: https://github.com/JabRef/jabref/issues/11082

The underlying issue is https://github.com/JabRef/JabRefOnline/issues/2176. There was a fix attempt made (https://github.com/JabRef/JabRefOnline/issues/2176#issuecomment-1687012154), but it was rejected in favor of a "far better" solution (https://github.com/JabRef/JabRefOnline/issues/2176#issuecomment-1688953053). However, no one implemented this.

I perceive that we upset users and force some users to stay at old versions. Our JabRef strategy (since about 10 years) is to "force" users to update to a new version - and make this transition smooth.

Thus, we should get the "quick fix" in - and work on a "perfect" fix later on.