### PR TITLE
chore: remove unnecessary code for deleting old deployment

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -62,8 +62,6 @@ jobs:
       - name: Deploy Web App
         id: deploy_web
         run: |
-          # Delete old deployment (otherwise we get a spawn EBUSY error when running the workflow again)
-          az staticwebapp environment delete --name jabref-online --environment-name $env:PREVIEW_NAME --yes || true
           # Workaround for https://github.com/Azure/static-web-apps-cli/issues/557 and https://github.com/Azure/static-web-apps-cli/issues/565
           $output = pnpm swa deploy .output\public --env $env:PREVIEW_NAME --verbose=silly 2>&1 | Out-String
           Write-Host $output


### PR DESCRIPTION
The EBUSY error still shows up sometimes, but now we get also an error if the env is still in "being deleted" state while trying to deploy the new version.