### PR TITLE
chore: update Apollo client import to use `core`

### DIFF
--- a/test/api-e2e/graphqlClient.ts
+++ b/test/api-e2e/graphqlClient.ts
@@ -2,7 +2,7 @@ import {
   type DocumentNode,
   type OperationVariables,
   type TypedDocumentNode,
-} from '@apollo/client'
+} from '@apollo/client/core'
 import { fetch } from '@nuxt/test-utils/e2e'
 import { print, type GraphQLError } from 'graphql'
 import { gql } from 'graphql-tag'


### PR DESCRIPTION
Since the main entry point pulls in react.