### PR TITLE
chore: ignore errors during function app detachment

### DIFF
--- a/.github/scripts/deploy.py
+++ b/.github/scripts/deploy.py
@@ -178,12 +178,15 @@ def main(environment_name: str, verbose: bool = False):
     for app in linked_function_apps:
         logger.info(f"Detaching function app {app.name}")
         logger.debug(f"{app}")
-        web_client.static_sites.detach_user_provided_function_app_from_static_site_build(
-            resource_group_name=GROUP_NAME,
-            name=STATIC_SITE,
-            environment_name=environment_name,
-            function_app_name=app.name,
-        )
+        try:
+            web_client.static_sites.detach_user_provided_function_app_from_static_site_build(
+                resource_group_name=GROUP_NAME,
+                name=STATIC_SITE,
+                environment_name=environment_name,
+                function_app_name=app.name,
+            )
+        except Exception as e:
+            logger.error(f"Failed to detach function app {app.name}: {e}")
 
     # Attach new function app
     poller_link = web_client.static_sites.begin_register_user_provided_function_app_with_static_site_build(


### PR DESCRIPTION
<!--
☝️ PR title should follow conventional commits (https://conventionalcommits.org).
In particular, the title should start with one of the following types:

- docs: 📖 Documentation (updates to the documentation or readme)
- fix: 🐞 Bug fix (a non-breaking change that fixes an issue)
- feat: ✨ New feature/enhancement (a non-breaking change that adds functionality or improves existing one)
- feat!/fix!: ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- chore: 🧹 Chore (updates to the build process or auxiliary tools and libraries)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### 📚 Description

Not sure why,  but sometimes detaching an function app fails:
```
 Detaching function app jabref-function-dev
Traceback (most recent call last):
  File "D:\a\JabRefOnline\JabRefOnline\.github\scripts\deploy.py", line 221, in <module>
    main(**vars(args))
    ~~~~^^^^^^^^^^^^^^
  File "D:\a\JabRefOnline\JabRefOnline\.github\scripts\deploy.py", line 181, in main
    web_client.static_sites.detach_user_provided_function_app_from_static_site_build(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        resource_group_name=GROUP_NAME,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        function_app_name=app.name,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "C:\hostedtoolcache\windows\Python\3.13.2\x64\Lib\site-packages\azure\core\tracing\decorator.py", line 119, in wrapper_use_tracer
    return func(*args, **kwargs)
  File "C:\hostedtoolcache\windows\Python\3.13.2\x64\Lib\site-packages\azure\mgmt\web\v2024_04_01\operations\_static_sites_operations.py", line 6173, in detach_user_provided_function_app_from_static_site_build
    map_error(status_code=response.status_code, response=response, error_map=error_map)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\hostedtoolcache\windows\Python\3.13.2\x64\Lib\site-packages\azure\core\exceptions.py", line 163, in map_error
    raise error
azure.core.exceptions.ResourceNotFoundError: Operation returned an invalid status 'Not Found'
Content: {"Code":"NotFound","Message":"Resource Not Found","Target":null,"Details":null,"Innererror":null}
```

In this case, just continue by trying to create a new function app (which then might still fail)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
