### PR TITLE
Feat/2518 GitHub link title bar

### DIFF
--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -143,7 +143,7 @@
       class="flex-1 flex items-center justify-end mx-3 md:mx-6"
     >
       <a
-        v-if="showGitHubLink"
+        v-if="showGithubLink"
         href="https://github.com/JabRef/jabref"
         target="_blank"
         rel="noopener noreferrer"
@@ -188,13 +188,13 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  showGitHubLink: {
+  showGithubLink: {
     type: Boolean,
     default: false,
   },
 })
 
-const { stars } = props.showGitHubLink
+const { stars } = props.showGithubLink
   ? useGitHubStars('JabRef/jabref')
   : { stars: ref<string | null>(null) }
 

--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    class="w-full flex flex-row flex-wrap items-center bg-white px-6 border-b border-muted h-20"
+    class="w-full flex flex-row flex-wrap items-center justify-between bg-white px-6 border-b border-muted h-20"
   >
     <!-- Logo -->
     <div
@@ -82,11 +82,8 @@
       </template>
     </UPopover>
 
-    <!-- Main menu (centered) -->
-    <div
-      v-show="!isSmallDisplay"
-      class="flex-1 flex justify-center"
-    >
+    <!-- Main menu -->
+    <div v-show="!isSmallDisplay">
       <slot>
         <div class="space-x-14">
           <span class="text-primary-600 text-lg font-semibold">Library</span>
@@ -106,15 +103,51 @@
       </slot>
     </div>
 
-    <!-- Right-side actions -->
-    <div class="flex items-center gap-4 ml-auto">
-      <!-- GitHub link -->
+    <!-- User profile -->
+    <nav
+      v-if="showUserProfile"
+      class="flex items-center pr-10 space-x-7"
+    >
+      <Icon
+        name="ri:notification-3-fill"
+        class="text-dimmed hover:text-primary-500 text-lg"
+      />
+      <div>
+        <!-- User profile dropdown -->
+        <UDropdownMenu
+          :content="{ align: 'end' }"
+          :items="[
+            [{ label: 'Your Profile' }, { label: 'Settings' }],
+            [{ label: 'Logout', onSelect: () => logout() }],
+          ]"
+        >
+          <button
+            id="user-menu"
+            class="w-12 h-12"
+            aria-label="User menu"
+            aria-haspopup="true"
+          >
+            <img
+              class="rounded-full"
+              src="https://a7sas.net/wp-content/uploads/2019/07/4060.jpeg"
+              alt=""
+            />
+          </button>
+        </UDropdownMenu>
+      </div>
+    </nav>
+
+    <!-- Right spacer — also holds the GitHub link to keep menu centred -->
+    <div
+      v-show="!isSmallDisplay"
+      class="flex-1 flex items-center justify-end mx-3 md:mx-6"
+    >
       <a
         v-if="showGitHubLink"
         href="https://github.com/JabRef/jabref"
         target="_blank"
         rel="noopener noreferrer"
-        class="hidden md:flex items-center gap-1.5 text-dimmed hover:text-primary-600 transition-colors"
+        class="flex items-center gap-1.5 text-dimmed hover:text-primary-600 transition-colors"
         aria-label="JabRef on GitHub"
       >
         <Icon
@@ -127,40 +160,6 @@
           >{{ stars }}</span
         >
       </a>
-
-      <!-- User profile -->
-      <nav
-        v-if="showUserProfile"
-        class="flex items-center space-x-7"
-      >
-        <Icon
-          name="ri:notification-3-fill"
-          class="text-dimmed hover:text-primary-500 text-lg"
-        />
-        <div>
-          <!-- User profile dropdown -->
-          <UDropdownMenu
-            :content="{ align: 'end' }"
-            :items="[
-              [{ label: 'Your Profile' }, { label: 'Settings' }],
-              [{ label: 'Logout', onSelect: () => logout() }],
-            ]"
-          >
-            <button
-              id="user-menu"
-              class="w-12 h-12"
-              aria-label="User menu"
-              aria-haspopup="true"
-            >
-              <img
-                class="rounded-full"
-                src="https://a7sas.net/wp-content/uploads/2019/07/4060.jpeg"
-                alt=""
-              />
-            </button>
-          </UDropdownMenu>
-        </div>
-      </nav>
     </div>
   </nav>
 </template>

--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -1,13 +1,13 @@
 <template>
   <nav
-    class="w-full flex flex-row flex-wrap items-center justify-between bg-white px-6 border-b border-muted h-20"
+    class="w-full flex flex-row flex-wrap items-center bg-white px-6 border-b border-muted h-20"
   >
     <!-- Logo -->
     <div
       v-if="showLogo"
       class="flex-1 flex flex-row items-center h-20 border-b mx-3 md:mx-6"
     >
-      <jabref-logo class="w-10 flex-none" />
+      <jabref-logo class="w-12 flex-none" />
       <span
         class="ml-3 flex-1 text-highlighted text-2xl font-semibold lg:inline-block hidden"
       >
@@ -82,8 +82,11 @@
       </template>
     </UPopover>
 
-    <!-- Main menu -->
-    <div v-show="!isSmallDisplay">
+    <!-- Main menu (centered) -->
+    <div
+      v-show="!isSmallDisplay"
+      class="flex-1 flex justify-center"
+    >
       <slot>
         <div class="space-x-14">
           <span class="text-primary-600 text-lg font-semibold">Library</span>
@@ -103,45 +106,62 @@
       </slot>
     </div>
 
-    <!-- User profile -->
-    <nav
-      v-if="showUserProfile"
-      class="flex items-center pr-10 space-x-7"
-    >
-      <Icon
-        name="ri:notification-3-fill"
-        class="text-dimmed hover:text-primary-500 text-lg"
-      />
-      <div>
-        <!-- User profile dropdown -->
-        <UDropdownMenu
-          :content="{ align: 'end' }"
-          :items="[
-            [{ label: 'Your Profile' }, { label: 'Settings' }],
-            [{ label: 'Logout', onSelect: () => logout() }],
-          ]"
+    <!-- Right-side actions -->
+    <div class="flex items-center gap-4 ml-auto">
+      <!-- GitHub link -->
+      <a
+        v-if="showGitHubLink"
+        href="https://github.com/JabRef/jabref"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="hidden md:flex items-center gap-1.5 text-dimmed hover:text-primary-600 transition-colors"
+        aria-label="JabRef on GitHub"
+      >
+        <Icon
+          name="ri:github-fill"
+          class="text-2xl"
+        />
+        <span
+          v-if="stars"
+          class="text-sm font-medium"
+          >{{ stars }}</span
         >
-          <button
-            id="user-menu"
-            class="w-12 h-12"
-            aria-label="User menu"
-            aria-haspopup="true"
-          >
-            <img
-              class="rounded-full"
-              src="https://a7sas.net/wp-content/uploads/2019/07/4060.jpeg"
-              alt=""
-            />
-          </button>
-        </UDropdownMenu>
-      </div>
-    </nav>
+      </a>
 
-    <!-- Empty stopper for proper alignment -->
-    <div
-      v-show="!isSmallDisplay"
-      class="flex-1 mx-3 md:mx-6"
-    />
+      <!-- User profile -->
+      <nav
+        v-if="showUserProfile"
+        class="flex items-center space-x-7"
+      >
+        <Icon
+          name="ri:notification-3-fill"
+          class="text-dimmed hover:text-primary-500 text-lg"
+        />
+        <div>
+          <!-- User profile dropdown -->
+          <UDropdownMenu
+            :content="{ align: 'end' }"
+            :items="[
+              [{ label: 'Your Profile' }, { label: 'Settings' }],
+              [{ label: 'Logout', onSelect: () => logout() }],
+            ]"
+          >
+            <button
+              id="user-menu"
+              class="w-12 h-12"
+              aria-label="User menu"
+              aria-haspopup="true"
+            >
+              <img
+                class="rounded-full"
+                src="https://a7sas.net/wp-content/uploads/2019/07/4060.jpeg"
+                alt=""
+              />
+            </button>
+          </UDropdownMenu>
+        </div>
+      </nav>
+    </div>
   </nav>
 </template>
 
@@ -156,7 +176,7 @@ const isHamburgerShown = ref(false)
 
 const isSmallDisplay = useBreakpoints(breakpointsTailwind).smallerOrEqual('md')
 
-defineProps({
+const props = defineProps({
   showLogo: {
     type: Boolean,
     default: false,
@@ -169,7 +189,15 @@ defineProps({
     type: Boolean,
     default: false,
   },
+  showGitHubLink: {
+    type: Boolean,
+    default: false,
+  },
 })
+
+const { stars } = props.showGitHubLink
+  ? useGitHubStars('JabRef/jabref')
+  : { stars: ref<string | null>(null) }
 
 const { resolveClient } = useApolloClient()
 

--- a/composables/useGitHubStars.ts
+++ b/composables/useGitHubStars.ts
@@ -2,14 +2,21 @@ export function useGitHubStars(repo: string) {
   const stars = ref<string | null>(null)
 
   if (import.meta.client) {
-    fetch(`https://api.github.com/repos/${repo}`)
-      .then((res) => res.json())
-      .then((data: { stargazers_count?: number }) => {
-        if (data.stargazers_count !== undefined) {
-          stars.value = formatStarCount(data.stargazers_count)
+    fetch(`/api/githubStars?repo=${encodeURIComponent(repo)}`)
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`Failed to fetch GitHub stars: ${res.statusText}`)
+        }
+        return res.json()
+      })
+      .then((data: { stars?: number }) => {
+        if (data.stars !== undefined) {
+          stars.value = formatStarCount(data.stars)
         }
       })
-      .catch(() => {})
+      .catch((error) => {
+        console.debug('Failed to fetch GitHub stars:', error)
+      })
   }
 
   return { stars }

--- a/composables/useGitHubStars.ts
+++ b/composables/useGitHubStars.ts
@@ -1,0 +1,23 @@
+export function useGitHubStars(repo: string) {
+  const stars = ref<string | null>(null)
+
+  if (import.meta.client) {
+    fetch(`https://api.github.com/repos/${repo}`)
+      .then((res) => res.json())
+      .then((data: { stargazers_count?: number }) => {
+        if (data.stargazers_count !== undefined) {
+          stars.value = formatStarCount(data.stargazers_count)
+        }
+      })
+      .catch(() => {})
+  }
+
+  return { stars }
+}
+
+function formatStarCount(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}K`
+  }
+  return count.toString()
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,7 +5,7 @@
         <NavBar
           :show-search-bar="false"
           :show-logo="true"
-          :show-git-hub-link="true"
+          :show-github-link="true"
         >
           <div class="space-x-14">
             <t-nuxtlink

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,6 +5,7 @@
         <NavBar
           :show-search-bar="false"
           :show-logo="true"
+          :show-git-hub-link="true"
         >
           <div class="space-x-14">
             <t-nuxtlink
@@ -28,6 +29,20 @@
                   :href="link.href"
                   >{{ link.title }}</t-nuxtlink
                 >
+              </li>
+              <li>
+                <a
+                  href="https://github.com/JabRef/jabref"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="hover:text-primary-600 font-semibold inline-flex items-center gap-1.5"
+                >
+                  <Icon
+                    name="ri:github-fill"
+                    class="text-lg"
+                  />
+                  GitHub
+                </a>
               </li>
             </ul>
           </template>

--- a/server/api/githubStars.ts
+++ b/server/api/githubStars.ts
@@ -1,0 +1,31 @@
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const repo = query.repo as string
+
+  if (!repo) {
+    throw createError({
+      statusCode: 400,
+      message: 'Missing repo parameter',
+    })
+  }
+
+  try {
+    const response = await fetch(`https://api.github.com/repos/${repo}`)
+
+    if (!response.ok) {
+      throw new Error(`GitHub API responded with ${response.status}`)
+    }
+
+    const data = (await response.json()) as { stargazers_count?: number }
+
+    return {
+      stars: data.stargazers_count ?? 0,
+    }
+  } catch (error) {
+    console.debug('Failed to fetch GitHub stars for repo', repo, error)
+    throw createError({
+      statusCode: 500,
+      message: 'Failed to fetch GitHub stars',
+    })
+  }
+})


### PR DESCRIPTION
## feat: Add GitHub link with star count to navbar

### 🔗 Linked issue

Resolves #2518

### 📚 Description

Added a GitHub icon with star count to the top-right corner of the landing page navbar, similar to other open-source projects like Nuxt.com. This makes it easier for users to navigate to the JabRef GitHub repository directly from the website.

**Changes:**
- Added `showGitHubLink` prop to NavBar component
- Created `useGitHubStars` composable to fetch and format GitHub star count from the API
- Positioned GitHub icon in the navbar's right corner
<img width="1920" height="1011" alt="Screenshot 2026-03-19 at 10 21 18 AM" src="https://github.com/user-attachments/assets/a0c6b70e-af52-4510-9f0e-a5576929e915" />
