### PR TITLE
fix: use buttons for footer modal actions

### DIFF
--- a/components/LandingPageFooter.vue
+++ b/components/LandingPageFooter.vue
@@ -67,20 +67,22 @@
             </t-nuxtlink>
           </li>
           <li class="py-1">
-            <t-nuxtlink
-              class="no-underline text-sm text-highlighted hover:text-primary-800"
+            <button
+              type="button"
+              class="cursor-pointer border-0 bg-transparent p-0 text-sm text-highlighted hover:text-primary-800"
               @click="showLegalNotices = true"
             >
               Legal Notices
-            </t-nuxtlink>
+            </button>
           </li>
           <li class="py-1">
-            <t-nuxtlink
-              class="no-underline text-sm text-highlighted hover:text-primary-800"
+            <button
+              type="button"
+              class="cursor-pointer border-0 bg-transparent p-0 text-sm text-highlighted hover:text-primary-800"
               @click="showPrivacyPolicy = true"
             >
               Privacy Policy
-            </t-nuxtlink>
+            </button>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
This changes the footer entries for Legal Notices and Privacy Policy from links to buttons, since they open dialogs instead of navigating. This makes it so a hand cursor appears while hovering over them instead of a text cursor.  


https://github.com/user-attachments/assets/2bd18354-535b-4ac7-8ac2-20e39b8d14f4



Closes #2010.